### PR TITLE
BenchmarkDotNet generates an isolated project with incorrect version …

### DIFF
--- a/Oleander.Extensions.Logging.File.Benchmarks/Oleander.Extensions.Logging.File.Benchmarks.sln.DotSettings
+++ b/Oleander.Extensions.Logging.File.Benchmarks/Oleander.Extensions.Logging.File.Benchmarks.sln.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Datagram/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unparameterized/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Oleander.Extensions.Logging.File.Benchmarks/src/FileLoggingBenchmark.cs
+++ b/Oleander.Extensions.Logging.File.Benchmarks/src/FileLoggingBenchmark.cs
@@ -117,7 +117,5 @@ namespace Oleander.Extensions.Logging.File.Benchmarks
 
             logger.AddCallerInfos().LogDebug($"TotalMilliseconds: {totalMilliseconds}");
         }
-    } 
-    
-    
+    }
 }

--- a/Oleander.Extensions.Logging.File.Benchmarks/src/Oleander.Extensions.Logging.File.Benchmarks.csproj
+++ b/Oleander.Extensions.Logging.File.Benchmarks/src/Oleander.Extensions.Logging.File.Benchmarks.csproj
@@ -1,21 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\..\.targets\common.targets" />
+
   <PropertyGroup>
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
-  <Import Project="..\..\.targets\common.targets" />
-
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\Oleander.Extensions.Logging.Abstractions\src\Oleander.Extensions.Logging.Abstractions.csproj" />
-    <ProjectReference Include="..\..\Oleander.Extensions.Logging.File\src\Oleander.Extensions.Logging.File.csproj" />
-    <ProjectReference Include="..\..\Oleander.Extensions.Logging\src\Oleander.Extensions.Logging.csproj" />
+    <PackageReference Include="Oleander.Extensions.Logging.Abstractions" Version="1.0.23075.1401-dev" />
+    <PackageReference Include="Oleander.Extensions.Logging.File" Version="1.0.23075.1401-dev" />
   </ItemGroup>
 
 </Project>

--- a/Oleander.Extensions.Logging.File.Benchmarks/src/Program.cs
+++ b/Oleander.Extensions.Logging.File.Benchmarks/src/Program.cs
@@ -87,8 +87,6 @@ namespace Oleander.Extensions.Logging.File.Benchmarks
             }
         }
 
-
-
         public static void LongRunningAddCallerInfosTest(string fileNameTemplate, bool parameterized)
         {
             lock (syncObj)

--- a/Oleander.Extensions.Logging.File.Benchmarks/src/Properties/launchSettings.json
+++ b/Oleander.Extensions.Logging.File.Benchmarks/src/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Oleander.Extensions.Logging.File.Benchmarks": {
+      "commandName": "Project",
+      "commandLineArgs": "--logBuildOutput"
+    }
+  }
+}


### PR DESCRIPTION
…information because version.targets is never executed. Nuget packages are used from now on.